### PR TITLE
fix(hook): Fix useTransform deep dependency check for filters.

### DIFF
--- a/lib/hooks/useTransform.ts
+++ b/lib/hooks/useTransform.ts
@@ -20,7 +20,7 @@ export function useTransform<T, U>(
 ): NevoProps<U> {
   const value = useMemo(
     () => options.value(props.value),
-    [props.value, options.value],
+    [JSON.stringify(props.value), options.value],
   );
   const onChange: ValueMutator<U> | undefined = useMemo(
     () =>


### PR DESCRIPTION
This is a fix for airvantage filters. When the field of the filter change, not the whole object change, only a key, resulting in a failing memoization (the object haven't change) and therefore the filter is wrongly memoized and doesn't update.

In case of "heavy" object, this solution may not be optimal tho. We could use a deep comparison function. 